### PR TITLE
MapContains should not use comparable for map value constraint

### DIFF
--- a/checker.go
+++ b/checker.go
@@ -455,7 +455,7 @@ func SliceContains[T any](container []T, elem T) Checker {
 
 // MapContains returns a Checker that succeeds if the given
 // map contains the given value, by comparing for equality.
-func MapContains[K, V comparable](container map[K]V, elem V) Checker {
+func MapContains[K comparable, V any](container map[K]V, elem V) Checker {
 	return MapAny(container, F2(Equals[V], elem))
 }
 

--- a/checker_test.go
+++ b/checker_test.go
@@ -1255,6 +1255,23 @@ want:
   "d"
 `,
 }, {
+	about: "Contains with map and interface value",
+	checker: qt.MapContains(map[string]interface{}{
+		"a": "d",
+		"b": "a",
+	}, "d"),
+	expectedNegateFailure: `
+error:
+  unexpected success
+container:
+  map[string]interface {}{
+      "a": "d",
+      "b": "a",
+  }
+want:
+  "d"
+`,
+}, {
 	about:   "All slice equals",
 	checker: qt.SliceAll([]string{"a", "a"}, qt.F2(qt.Equals[string], "a")),
 	expectedNegateFailure: `


### PR DESCRIPTION
This follows a similar logic to Equals - it needs to work with interface
types too.