### PR TITLE
Call TB.Helper from Assert and Check

### DIFF
--- a/quicktest.go
+++ b/quicktest.go
@@ -9,6 +9,7 @@ import (
 // Assert checks that the provided argument passes the given check and calls
 // tb.Fatal otherwise, including any Comment arguments in the failure.
 func Assert(t testing.TB, checker Checker, comments ...Comment) bool {
+	t.Helper()
 	return check(t, checkParams{
 		fail:     t.Fatal,
 		checker:  checker,
@@ -19,6 +20,7 @@ func Assert(t testing.TB, checker Checker, comments ...Comment) bool {
 // Check checks that the provided argument passes the given check and calls
 // tb.Error otherwise, including any Comment arguments in the failure.
 func Check(t testing.TB, checker Checker, comments ...Comment) bool {
+	t.Helper()
 	return check(t, checkParams{
 		fail:     t.Error,
 		checker:  checker,

--- a/quicktest_test.go
+++ b/quicktest_test.go
@@ -266,6 +266,20 @@ func TestCAssertCheck(t *testing.T) {
 	}
 }
 
+func TestHelperCalls(t *testing.T) {
+	tt := &testingT{}
+	qt.Assert(tt, qt.IsTrue(false))
+	if tt.helperCalls < 2 {
+		t.Error("Assert doesn't invoke TB.Helper()")
+	}
+
+	tt = &testingT{}
+	qt.Check(tt, qt.IsTrue(false))
+	if tt.helperCalls < 2 {
+		t.Error("Check doesn't invoke TB.Helper()")
+	}
+}
+
 func checkResult(t *testing.T, ok bool, got, want string) {
 	t.Helper()
 	if want != "" {


### PR DESCRIPTION
Assertions and Checks currently don't call TB.Helper() directly, which leads to test output like the following:

    === FAIL: . TestMapBatch/PerCPUArray (0.01s)
        quicktest.go:12:
            error:
              got non-nil value
            got:
              e"batch update: not supported"
            stack:
              /home/runner/actions-runner/_work/ebpf/ebpf/map_test.go:148
                qt.Assert(t, qt.IsNil(err))

Note that the first source location is that of qt.Assert. The correct location can still be found from the stack trace, but that is at the end of the message instead of at the start.

Invoke TB.Helper in Assert and Check so that the Go testing package reports a more accurate / interesting location.