### PR TITLE
Allow pointer to array for HasLen

### DIFF
--- a/checker_test.go
+++ b/checker_test.go
@@ -1168,6 +1168,19 @@ want length:
   <same as "len(got)">
 `,
 }, {
+	about:   "HasLen: pointers to array with the same length",
+	checker: qt.HasLen(&[4]string{"these", "are", "the", "voyages"}, 4),
+	expectedNegateFailure: `
+error:
+  unexpected success
+len(got):
+  int(4)
+got:
+  &[4]string{"these", "are", "the", "voyages"}
+want length:
+  <same as "len(got)">
+`,
+}, {
 	about:   "HasLen: channels with the same length",
 	checker: qt.HasLen(chInt, 2),
 	expectedNegateFailure: fmt.Sprintf(`
@@ -1298,6 +1311,21 @@ error:
   bad check: first argument of type int has no length
 got:
   int(42)
+`,
+}, {
+	about:   "HasLen: pointer value without a length",
+	checker: qt.HasLen(&[]string{"arrays", "are", "fine", "but", "not", "slices"}, 1),
+	expectedCheckFailure: `
+error:
+  bad check: first argument of type *[]string has no length
+got:
+  &[]string{"arrays", "are", "fine", "but", "not", "slices"}
+`,
+	expectedNegateFailure: `
+error:
+  bad check: first argument of type *[]string has no length
+got:
+  &[]string{"arrays", "are", "fine", "but", "not", "slices"}
 `,
 }, {
 	about:   "Implements: implements interface",

--- a/format.go
+++ b/format.go
@@ -79,7 +79,7 @@ func checkStringCall(v any, f func() string) (s string, ok bool) {
 		if err == nil {
 			return
 		}
-		if val := reflect.ValueOf(v); val.Kind() == reflect.Ptr && val.IsNil() {
+		if val := reflect.ValueOf(v); val.Kind() == reflect.Pointer && val.IsNil() {
 			ok = false
 			return
 		}

--- a/qtsuite/suite.go
+++ b/qtsuite/suite.go
@@ -92,7 +92,7 @@ func Run(t *testing.T, suite any) {
 			}
 
 			sv := sv
-			if st.Kind() == reflect.Ptr {
+			if st.Kind() == reflect.Pointer {
 				sv1 := reflect.New(st.Elem())
 				sv1.Elem().Set(sv.Elem())
 				sv = sv1

--- a/report.go
+++ b/report.go
@@ -18,9 +18,6 @@ import (
 
 // reportParams holds parameters for reporting a test error.
 type reportParams struct {
-	// paramNames holds the names for the parameters of the checker
-	// (including got as the first name).
-	paramNames []string
 	// args holds all the arguments passed to the checker.
 	args []Arg
 	// comments optionally holds comments passed when performing the check.


### PR DESCRIPTION
## Description

According to `reflect` `(Value) Len() int` [godoc](https://pkg.go.dev/reflect#Value.Len), we can get the length of the pointer to an array:
```go
// Len returns v's length.
// It panics if v's Kind is not Array, Chan, Map, Slice, String, or pointer to Array.
```

It means that the following piece of code must succeed in `go-quicktest/qt`:
```go
qt.Assert(t, qt.HasLen(&[2]string{"Monsieur", "André"}, 2))
```
However, the current checker of `HasLen` will return the following error for such a case:
```
bad check: first argument of type *[2]string has no length
```
even though the Golang native logic equates `len(&[2]string{"Monsieur", "André"}) == 2` to `true`.

This PR adds the logic for handling pointers to arrays and adds appropriate tests.

## Drive-by improvements

- Removing unused `emptyInterface`;
- Removing unused `paramNames` attribute in `reportParams`;
- Removing extra checks for types after we specified their type instead of `any`;
- Migrated `reflect.Ptr` to `reflect.Pointer` as it is now the new accepted standard naming.